### PR TITLE
Allow user-defined sidecars

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See values.yaml for a more complete listing.
 | <span style="font-family: monospace">config</span>                  | Map of environment variables to configure PhotoPrism's runtime behavior | |
 | <span style="font-family: monospace">config.PHOTOPRISM_DEBUG</span> | Enable verbose logging | |
 | <span style="font-family: monospace">config.PHOTOPRISM_PUBLIC</span> | Allow passwordless access | |
+| <span style="font-family: monospace">sidecarContainers</span>      | List of container images to run as sidecars | |
 | <span style="font-family: monospace">persistence.enabled</span>    | Enable persistent storage | <span style="font-family: monospace">true</span> |
 | <span style="font-family: monospace">persistence.importPath</span> | Path to imported images | <span style="font-family: monospace">/assets/photos/import</span> |
 | <span style="font-family: monospace">persistence.originalsPath</span> | Path to pre-existing photos | <span style="font-family: monospace">/assets/photos/originals</span> |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -59,7 +59,9 @@ spec:
           name: http
         volumeMounts:
           {{- toYaml .Values.persistence.volumeMounts | nindent 8 }}
-
+    {{- if .Values.sidecarContainers }}
+    {{- toYaml .Values.sidecarContainers | nindent 6 }}
+    {{- end }}
     {{- if and .Values.persistence.enabled .Values.persistence.volumes }}
       volumes:
       {{- toYaml .Values.persistence.volumes | nindent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,10 @@ config:
 # nodeSelector:
 #   kubernetes.io/hostname:
 
+# sidecarContainers:
+#   - name: sidecar
+#     image: alpine
+
 persistence:
   enabled: true
   storagePath:   &storagePath    /photoprism/storage


### PR DESCRIPTION
This PR introduces user-defined sidecars. My particular use-case is that photos and backups are stored on "ReadWriteOnce" PVCs. The only way to run backups is via sidecars because only one pod can mount the volume.