### PR TITLE
Fix ingress for modern k8s

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "photoprism.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -40,11 +41,11 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: 80
+                  number: {{ $svcPort }}
             {{- else }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: 80
+              servicePort: {{ $svcPort }}
             {{- end }}
         {{- end }}
   {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -28,22 +28,24 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+  {{- range $.Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
-                  number: http
-              {{- else }}
+                  number: 80
+            {{- else }}
+            backend:
               serviceName: {{ $fullName }}
-              servicePort: http
-              {{- end }}
+              servicePort: 80
+            {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -31,12 +31,6 @@ spec:
       - name: photoprism
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-
-        env:
-        - name: PHOTOPRISM_HTTP_HOST
-          value: 0.0.0.0
-        - name: PHOTOPRISM_HTTP_PORT
-          value: "2342"
         envFrom:
         - configMapRef:
             name: environment

--- a/values.yaml
+++ b/values.yaml
@@ -69,18 +69,11 @@ service:
 
 ingress:
   enabled: false
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    kubernetes.io/tls-acme: "true"
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
   hosts:
   - host: my.domain.com
     paths:
     - /
-  tls:
-  - hosts:
-    - my.domain.com
-    secretName: photoprism-cert
+  tls: []
 
 # securityContext:
 #   fsGroup: 100


### PR DESCRIPTION
 - Need to have `pathType` for the Ingress spec in `>=1.19-0`. 
 - Use `Values.service.port` rather than a hard-coded `80 / http`