### PR TITLE
Add extraObjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See values.yaml for a more complete listing.
 | <span style="font-family: monospace">database.host</span>          | Remote database host | <span style="font-family: monospace">nil</span> |
 | <span style="font-family: monospace">database.port</span>          | Remote database port | <span style="font-family: monospace">nil</span> |
 | <span style="font-family: monospace">database.existingSecret</span> | Use existing secret for database DSN (key PHOTOPRISM_DATABASE_DSN) | |
+| <span style="font-family: monospace">extraObjects</span>           | Extra K8s manifests to deploy | <span style="font-family: monospace">[]</span> |
 
 
 For setting nested values, it's generally easiest to just specify a YAML file that with the correct values:

--- a/templates/extra-resources.yaml
+++ b/templates/extra-resources.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -111,3 +111,19 @@ database:
   # host: mariadb.db-mariadb
 # Ignore above settings and use existing secret for database DSN. Key 'PHOTOPRISM_DATABASE_DSN'
   # existingSecret:
+
+# -- Extra K8s manifests to deploy
+extraObjects: []
+#  - apiVersion: v1
+#    kind: PersistentVolume
+#    metadata:
+#      name: aws-efs
+#    data:
+#      key: "value"
+#  - apiVersion: scheduling.k8s.io/v1
+#    kind: PriorityClass
+#    metadata:
+#      name: high-priority
+#    value: 1000000
+#    globalDefault: false
+#    description: "This priority class should be used for XYZ service pods only."


### PR DESCRIPTION
Add `extraObjects` in values and support to apply any extra kubernertes resources in the same lifecycle of the chart.

Often users need to apply various kubernetes resources like NetworkPolicy, PriorityClass, StorageClass, CRD and so on.

There are lots of projects that implement `extraObjects` in the values.yaml.
e.g.
- https://github.com/cert-manager/cert-manager/pull/6424
- https://github.com/kubernetes/autoscaler/pull/7243
- https://github.com/traefik/traefik-helm-chart/pull/643
